### PR TITLE
Heroku container deploy strategy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 0, "build-stage", based on Node.js, to build and compile the frontend
+FROM tiangolo/node-frontend:10 as build-stage
+WORKDIR /app
+COPY package*.json /app/
+RUN npm install
+COPY ./ /app/
+ARG configuration=production
+RUN npm run build -- --output-path=./dist/out --configuration $configuration
+# Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
+FROM nginx:1.15
+COPY --from=build-stage /app/dist/out/ /usr/share/nginx/html
+# Copy the default nginx.conf provided by tiangolo/node-frontend
+COPY default.conf.template /etc/nginx/conf.d/default.conf.template
+CMD /bin/bash -c "envsubst '\$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf" && nginx -g 'daemon off;'

--- a/default.conf.template
+++ b/default.conf.template
@@ -1,0 +1,11 @@
+server {
+  listen $PORT;
+  
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+  
+  include /etc/nginx/extra-conf.d/*.conf;
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
This small addition to the repo will permit Heroku to build this application as a runnable docker image on Heroku.  You can see the deployed fork [here](https://plan-of-studies.herokuapp.com/alldepwin).